### PR TITLE
Omnibus merge of Debian downstream patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,15 @@
 
 VERSION = 3.6.0
 
-CC	= gcc
-CFLAGS	= -I./src -I./userial -O2 -Wall # -g
+SRCDIR	= $(CURDIR)
+VPATH	= $(SRCDIR)
+
+# May be overridden by the command line
+CFLAGS = -O2 -Wall # -g
+
+# Mandatory additions to CFLAGS
+EXTRACFLAGS	= -I$(SRCDIR)/src -I$(SRCDIR)/userial
+override CFLAGS	+= $(EXTRACFLAGS)
 
 OBJS		=	src/digitemp.o src/device_name.o src/ds2438.o
 HDRS		= 	src/digitemp.h src/device_name.h
@@ -48,7 +55,7 @@ DS2490OBJS	=	userial/ds2490/ownet.o userial/ds2490/owtran.o \
 SYSTYPE := $(shell uname -s)
 
 ifeq ($(SYSTYPE), Linux)
-  CFLAGS += -DLINUX
+  EXTRACFLAGS += -DLINUX
 
   # Set LOCK to yes for serial port locking support
   LOCK = no
@@ -56,44 +63,44 @@ ifeq ($(SYSTYPE), Linux)
 endif
 
 ifneq (, $(findstring CYGWIN,$(SYSTYPE)))
-  CFLAGS += -DCYGWIN
+  EXTRACFLAGS += -DCYGWIN
   LIBS   += -static -static-libgcc
 endif
 
 ifeq ($(SYSTYPE), SunOS)
-  CFLAGS += -DSOLARIS
+  EXTRACFLAGS += -DSOLARIS
   LIBS   += -lposix4
 endif
 
 ifeq ($(SYSTYPE), FreeBSD)
-  CFLAGS += -DFREEBSD
+  EXTRACFLAGS += -DFREEBSD
 endif
 
 ifeq ($(SYSTYPE), OpenBSD)
-  CFLAGS += -DOPENBSD
+  EXTRACFLAGS += -DOPENBSD
 endif
 
 # Untested, but should work.
 ifeq ($(SYSTYPE), NetBSD)
-  CFLAGS += -DNETBSD
+  EXTRACFLAGS += -DNETBSD
 endif
 
 ifeq ($(SYSTYPE), Darwin)
-  CFLAGS += -DDARWIN
+  EXTRACFLAGS += -DDARWIN
 endif
 
 ifeq ($(SYSTYPE), AIX)
-  CFLAGS += -DAIX
+  EXTRACFLAGS += -DAIX
 endif
 
 ifeq ($(LOCK), yes)
-  CFLAGS += -DLOCKDEV
+  EXTRACFLAGS += -DLOCKDEV
   LIBS   += -llockdev
 endif
 
 
 # USB specific flags
-ds2490:  CFLAGS += -DOWUSB
+ds2490:  EXTRACFLAGS += -DOWUSB
 ds2490:  LIBS   += -lusb
 
 
@@ -116,13 +123,13 @@ all:		help
 
 # Build the Linux executable
 ds9097:		$(OBJS) $(HDRS) $(ONEWIREOBJS) $(ONEWIREHDRS) $(DS9097OBJS)
-		$(CC) $(OBJS) $(ONEWIREOBJS) $(DS9097OBJS) -o digitemp_DS9097 $(LIBS)
+		$(CC) $(OBJS) $(ONEWIREOBJS) $(DS9097OBJS) -o digitemp_DS9097 $(LDFLAGS) $(LIBS)
 
 ds9097u:	$(OBJS) $(HDRS) $(ONEWIREOBJS) $(ONEWIREHDRS) $(DS9097UOBJS)
-		$(CC) $(OBJS) $(ONEWIREOBJS) $(DS9097UOBJS) -o digitemp_DS9097U $(LIBS)
+		$(CC) $(OBJS) $(ONEWIREOBJS) $(DS9097UOBJS) -o digitemp_DS9097U $(LDFLAGS) $(LIBS)
 
 ds2490:		$(OBJS) $(HDRS) $(ONEWIREOBJS) $(ONEWIREHDRS) $(DS2490OBJS)
-		$(CC) $(OBJS) $(ONEWIREOBJS) $(DS2490OBJS) -o digitemp_DS2490 $(LIBS)
+		$(CC) $(OBJS) $(ONEWIREOBJS) $(DS2490OBJS) -o digitemp_DS2490 $(LDFLAGS) $(LIBS)
 
 
 # Clean up the object files and the sub-directory for distributions

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@
 #
 # Please note that this Makefile *needs* GNU make. BSD make won't do.
 #
-# To disable Lockfile support on Linux, chenage LOCK to no
-#
 
 VERSION = 3.6.0
 
@@ -56,10 +54,6 @@ SYSTYPE := $(shell uname -s)
 
 ifeq ($(SYSTYPE), Linux)
   EXTRACFLAGS += -DLINUX
-
-  # Set LOCK to yes for serial port locking support
-  LOCK = no
-
 endif
 
 ifneq (, $(findstring CYGWIN,$(SYSTYPE)))
@@ -91,11 +85,6 @@ endif
 
 ifeq ($(SYSTYPE), AIX)
   EXTRACFLAGS += -DAIX
-endif
-
-ifeq ($(LOCK), yes)
-  EXTRACFLAGS += -DLOCKDEV
-  LIBS   += -llockdev
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,6 @@ DS2490OBJS	=	userial/ds2490/ownet.o userial/ds2490/owtran.o \
 # -----------------------------------------------------------------------
 SYSTYPE := $(shell uname -s)
 
-ifeq ($(SYSTYPE), Linux)
-  EXTRACFLAGS += -DLINUX
-endif
-
 ifneq (, $(findstring CYGWIN,$(SYSTYPE)))
   EXTRACFLAGS += -DCYGWIN
   LIBS   += -static -static-libgcc
@@ -68,15 +64,6 @@ endif
 
 ifeq ($(SYSTYPE), FreeBSD)
   EXTRACFLAGS += -DFREEBSD
-endif
-
-ifeq ($(SYSTYPE), OpenBSD)
-  EXTRACFLAGS += -DOPENBSD
-endif
-
-# Untested, but should work.
-ifeq ($(SYSTYPE), NetBSD)
-  EXTRACFLAGS += -DNETBSD
 endif
 
 ifeq ($(SYSTYPE), Darwin)

--- a/digitemp.1
+++ b/digitemp.1
@@ -104,7 +104,7 @@ numeric values select pre-configured output formats:
     2 = One line per sample, elapsed time, temperature in C
     3 = Same as #2, except temperature is in F
 .PP
-#2 and #3 have the data seperated by tabs, suitable for import into a 
+#2 and #3 have the data separated by tabs, suitable for import into a
 spreadsheet or other graphing software.
 .PP
 The format string uses strftime tokens plus 5 special ones for

--- a/src/digitemp.c
+++ b/src/digitemp.c
@@ -75,68 +75,10 @@
 #include <stdint.h>
 #include "ad26.h"
 
-// Include endian.h
-#if DARWIN
-#include <machine/endian.h>
-#endif
-#if FREEBSD
-#include <sys/endian.h>
-#endif
-#if !defined(DARWIN) && !defined(FREEBSD)
-#include <endian.h>
-#endif
-
 #include "digitemp.h"
 #include "device_name.h"
 #include "ownet.h"
 #include "owproto.h"
-
-
-/* Setup the correct getopt starting point */
-#ifdef LINUX
-#define GETOPTEOF -1
-#define OPTINDSTART 0
-#endif
-
-#ifdef CYGWIN
-#define GETOPTEOF -1
-#define OPTINDSTART 0
-#endif
-
-#ifdef AIX
-#define OPTINDSTART 0
-#define GETOPTEOF 255
-#endif
- 
-#ifdef SOLARIS
-#define GETOPTEOF EOF
-#define OPTINDSTART 1
-#endif
-
-#ifdef FREEBSD
-#define GETOPTEOF EOF
-#define OPTINDSTART 1
-#endif
-
-#ifdef OPENBSD
-#define GETOPTEOF EOF
-#define OPTINDSTART 1
-#endif
-
-#ifdef NETBSD
-#define GETOPTEOF EOF
-#define OPTINDSTART 1
-#endif
-
-#ifdef DARWIN
-#define GETOPTEOF EOF
-#define OPTINDSTART 1
-#endif
- 
-#ifdef OTHER
-#define GETOPTEOF EOF
-#define OPTINDSTART 1
-#endif 
 
 
 /* For tracking down strange errors */
@@ -144,10 +86,6 @@
 
 extern char 	*optarg;              
 extern int	optind, opterr, optopt;
-
-#if defined(FREEBSD) || defined(DARWIN)
-extern int optreset;
-#endif /* FREEBSD or DARWIN */
 
 extern const char dtlib[];			/* Library Used            */
  
@@ -2462,10 +2400,9 @@ int main( int argc, char *argv[] )
   /* Unless the -i parameter is specified, then changes are saved to    */
   /* .digitemprc file                                                   */
 
-  optind = OPTINDSTART;
   opterr = 1;
 
-  while( (c = getopt(argc, argv, option_list)) != GETOPTEOF )
+  while( (c = getopt(argc, argv, option_list)) != -1 )
   {
     /* Process the command line arguments */
     switch( c )

--- a/src/digitemp.c
+++ b/src/digitemp.c
@@ -196,8 +196,8 @@ void usage()
   printf(BANNER_2);
   printf(BANNER_3, dtlib );		         /* Report Library version */
   printf("\nUsage: digitemp [-s -i -I -U -l -r -v -t -a -d -n -o -c]\n");
-  printf("                -i                            Initalize .digitemprc file\n");
-  printf("                -I                            Initalize .digitemprc file w/sorted serial #s\n");
+  printf("                -i                            Initialize .digitemprc file\n");
+  printf("                -I                            Initialize .digitemprc file w/sorted serial #s\n");
   printf("                -w                            Walk the full device tree\n");
   printf("                -s /dev/ttyS0                 Set serial port\n");
   printf("                -l /var/log/temperature       Send output to logfile\n");
@@ -218,7 +218,7 @@ void usage()
   printf("\nLogfile formats:  1 = One line per sensor, time, C, F (default)\n");
   printf("                  2 = One line per sample, elapsed time, temperature in C\n");
   printf("                  3 = Same as #2, except temperature is in F\n");
-  printf("        #2 and #3 have the data seperated by tabs, suitable for import\n");
+  printf("        #2 and #3 have the data separated by tabs, suitable for import\n");
   printf("        into a spreadsheet or other graphing software.\n");
   printf("\n        The format string uses strftime tokens plus 5 special ones for\n");
   printf("        digitemp - %%s for sensor #, %%C for centigrade, %%F for fahrenheit,\n");
@@ -2433,7 +2433,7 @@ int main( int argc, char *argv[] )
 
   if( argc <= 1 )
   {
-    fprintf(stderr,"Error! Not enough arguements.\n\n");
+    fprintf(stderr,"Error! Not enough arguments.\n\n");
     usage();
     return -1;
   }

--- a/src/digitemp.c
+++ b/src/digitemp.c
@@ -86,14 +86,6 @@
 #include <endian.h>
 #endif
 
-#ifdef LINUX
-#ifndef OWUSB
-#ifdef LOCKDEV
-#include <lockdev.h>
-#endif
-#endif
-#endif
-
 #include "digitemp.h"
 #include "device_name.h"
 #include "ownet.h"
@@ -2658,46 +2650,6 @@ int main( int argc, char *argv[] )
 
     exit(EXIT_NOPERM);
   }
-
-  /* Lock our use of the serial port, exit if it is in use */
-#ifdef LINUX
-#ifndef OWUSB
-#ifdef LOCKDEV
-  /* First turn serial_port into just the final device name */
-  if( !(p = strrchr( serial_port, '/' )) )
-  {
-    fprintf( stderr, "Error getting serial device from %s\n", serial_port );
-    
-    if( sensor_list.roms != NULL )
-      free( sensor_list.roms );
-
-    if( coupler_top != NULL )
-      free_coupler(1);
-
-    exit(EXIT_DEVERR);
-  }
-  strncpy( serial_dev, p+1, sizeof(serial_dev)-1 );
-
-  if( (pid = dev_lock( serial_dev )) != 0 )
-  {
-    if( pid == -1 )
-    {
-      fprintf( stderr, "Error locking %s. Do you have permission to write to /var/lock?\n", serial_dev );
-    } else {
-      fprintf( stderr, "Error, %s is locked by process %d\n", serial_dev, pid );
-    }
-      
-    if( sensor_list.roms != NULL )
-      free( sensor_list.roms );
-
-    if( coupler_top != NULL )
-      free_coupler(1);
-
-    exit(EXIT_LOCKED);
-  }
-#endif		/* LOCKDEV	*/
-#endif		/* OWUSB	*/
-#endif		/* LINUX 	*/
 #endif		/* !OWUSB 	*/
 
   /* Connect to the MLan network */
@@ -2719,13 +2671,6 @@ int main( int argc, char *argv[] )
     if( coupler_top != NULL )
       free_coupler(0);
 
-#ifdef LINUX
-#ifndef OWUSB
-#ifdef LOCKDEV
-    dev_unlock( serial_dev, 0 );
-#endif		/* LOCKDEV	*/
-#endif		/* OWUSB	*/
-#endif		/* LINUX	*/
     exit(EXIT_ERR);
   }
 
@@ -2746,14 +2691,6 @@ int main( int argc, char *argv[] )
 #else
       owRelease(0, temp );
 #endif /* OWUSB */
-
-#ifdef LINUX
-#ifndef OWUSB
-#ifdef LOCKDEV
-    dev_unlock( serial_dev, 0 );
-#endif		/* LOCKDEV	*/
-#endif		/* OWUSB	*/
-#endif		/* LINUX	*/
 
     exit(EXIT_OK);
   }
@@ -2779,14 +2716,6 @@ int main( int argc, char *argv[] )
       owRelease(0, temp );
       fprintf( stderr, "USB ERROR: %s\n", temp );
 #endif /* OWUSB */
-
-#ifdef LINUX
-#ifndef OWUSB
-#ifdef LOCKDEV
-      dev_unlock( serial_dev, 0 );
-#endif		/* LOCKDEV	*/
-#endif		/* OWUSB	*/
-#endif		/* LINUX	*/
 
       exit(EXIT_ERR);
     }
@@ -2871,14 +2800,6 @@ int main( int argc, char *argv[] )
 #else
   owRelease(0, temp );
 #endif /* OWUSB */
-
-#ifdef LINUX
-#ifndef OWUSB
-#ifdef LOCKDEV
-  dev_unlock( serial_dev, 0 );
-#endif		/* LOCKDEV	*/
-#endif		/* OWUSB	*/
-#endif		/* LINUX	*/
 
   exit(EXIT_OK);
 }

--- a/src/digitemp.h
+++ b/src/digitemp.h
@@ -19,7 +19,7 @@
    59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
    ----------------------------------------------------------------------- */
 #define BANNER_1     "DigiTemp v3.6.0 Copyright 1996-2009 by Brian C. Lane\n"
-#define BANNER_2     "GNU Public License v2.0 - http://www.digitemp.com\n"
+#define BANNER_2     "GNU General Public License v2.0 - http://www.digitemp.com\n"
 #define BANNER_3     "Compiled for %s\n\n"
 
 #define OPT_INIT     0x0001

--- a/userial/ds2490/usblnk.c
+++ b/userial/ds2490/usblnk.c
@@ -37,6 +37,7 @@
 #include "usb.h"
 #include <errno.h>
 #include <time.h>
+#include <assert.h>
 #include "usblnk.h"
 
 /* wrap in Linux? */
@@ -78,28 +79,61 @@ int owTouchReset(int portnum)
 {
 	int result; 
 	char buffer[0x20];
+	int count = 20;
+	int got_result = 0;
+	struct timespec to_wait = {0, 1000000}; // Wait for 1ms between polls
+	int keep_going = 1;
 
-	/* issue the 1-wire reset */
+	/* issue the 1-wire reset. Ensure the NTF bit is set so we can
+	   get results. */
 	result = usb_control_msg(usb_dev_handle_list[portnum], 0x40,
-			COMM_CMD, 0x0043, 0x0000, NULL, 0x0, TIMEOUT_VALUE);
+			COMM_CMD, 0x0443, 0x0000, NULL, 0x0, TIMEOUT_VALUE);
 	//printf("result is %d\n", result);
 
-	/* repeat until the unit is not idle */
+	/* repeat until:
+		- an error occurs, or
+		- the unit is idle, and we've either got a result, or
+			waited long enough that none is likely to come */
 	do {
 		/* get the status */
-		result = usb_bulk_read(usb_dev_handle_list[portnum], 0x81,
+		result = usb_interrupt_read(usb_dev_handle_list[portnum], 0x81,
 				buffer, 0x20, TIMEOUT_VALUE);
 		//printf("result is %d\n", result);
+		if (result < 0) {
+			keep_going = 0;
+		} else {
+			assert(result >= 0x10);
+			if (result > 0x10) {
+				got_result = 1;
+			}
+			if (buffer[0x08] & 0x20) {
+				/* Device is idle. Finish if we have a result
+				   or if we give up. */
+				if (got_result) {
+					keep_going = 0;
+				} else {
+					count--;
+					if (count == 0) {
+						keep_going = 0;
+					}
+				}
+			}
+		}
+		if (keep_going) {
+			nanosleep(&to_wait, NULL);
+		}
 
 		//for (result = 0; result < 0x20; result++) {
 		//	printf("%02X: %02X\n", result, buffer[result]);
 		//}
-	} while (!(buffer[0x08] & 0x20) && !(result < 0));
+	} while (keep_going);
 
 	if (result < 0)
 		return FALSE;
 
-	if (buffer[0x10] & 0x01) {
+        /* Only declare there was nothing on the bus if we got a result
+           otherwise we may just have missed it due to timing issues */
+	if (got_result && (buffer[0x10] & 0x01)) {
 		return FALSE;
 	} else {
 		return TRUE;

--- a/userial/ds9097/linuxses.c
+++ b/userial/ds9097/linuxses.c
@@ -39,6 +39,7 @@
 #include <termios.h>
 #include <fcntl.h>
 #include <ownet.h>
+#include <sys/file.h>
 
 /* local function prototypes */
 SMALLINT owAcquire(int,char *);
@@ -62,6 +63,14 @@ SMALLINT owAcquire(int portnum, char *port_zstr)
 	return FALSE;
      }
    
+   /* Lock the device */
+   if(flock(fd[portnum], LOCK_EX|LOCK_NB))
+     {
+	OWERROR(OWERROR_GET_SYSTEM_RESOURCE_FAILED);
+	perror("owAcquire: failed to open device");
+	return FALSE;
+     }
+
    /* Get device settings */
    if(tcgetattr(fd[portnum], &term[portnum] ) < 0 )
      {

--- a/userial/ds9097u/linuxlnk.c
+++ b/userial/ds9097u/linuxlnk.c
@@ -105,7 +105,7 @@ void      CloseCOM(int);
 void      FlushCOM(int);
 int       ReadCOM(int, int, uchar*);
 void      BreakCOM(int);
-void      SetBaudCOM(int, int);
+void      SetBaudCOM(int, uchar);
 void      msDelay(int);
 long      msGettick(void);
 
@@ -331,7 +331,7 @@ void BreakCOM(int portnum)
 // PARMSET_57600    0x04
 // PARMSET_115200   0x06
 //
-void SetBaudCOM(int portnum, int new_baud)
+void SetBaudCOM(int portnum, uchar new_baud)
 {
    struct termios t;
    int rc;

--- a/userial/ds9097u/linuxlnk.c
+++ b/userial/ds9097u/linuxlnk.c
@@ -93,6 +93,7 @@
 #include <termios.h>
 #include <errno.h>
 #include <sys/time.h>
+#include <sys/file.h>
 
 #include "ds2480.h"
 #include "ownet.h"
@@ -138,6 +139,14 @@ SMALLINT OpenCOM(int portnum, char *port_zstr)
       OWERROR(OWERROR_GET_SYSTEM_RESOURCE_FAILED);
       return FALSE;  // changed (2.00), used to return fd;
    }
+
+   /* Lock the device */
+   if(flock(fd[portnum], LOCK_EX|LOCK_NB))
+     {
+        OWERROR(OWERROR_GET_SYSTEM_RESOURCE_FAILED);
+        return FALSE;
+     }
+
    rc = tcgetattr (fd[portnum], &t);
    if (rc < 0)
    {


### PR DESCRIPTION
Per Issue #5, this PR includes all unmerged Debian downstream patches:

 * code-spelling.patch - Simple spelling corrections caught by lintian (which checks for common misspellings but isn't comprehensive).
 * makefile.patch - Allows for CFLAGS and LDFLAGS to be specified (for hardening), also allows for multiple builds for the different digitemp_* binaries in build directories using VPATH.
 * flock.patch - Replaces lockdev (which is deprecated upstream) with flock - see http://bugs.debian.org/728018 for details.
 * setbaudcom.patch - Fixes SetBaudCOM conflicting parameter types.
 * usb-reset-status.patch - Properly reset the 1-Wire bus on DS2490.  (Seems sane, reported in http://pad.lv/1397382 but I do not have access to a DS2490 to test.)
 * platform.patch - Removes platform-specific handling of getopt optind/eof stuff in favor of a way which is handled platform independently (and allows for other architectures such as Hurd/kFreeBSD which were FTBFSing in Debian).

While some of these changes are for the benefit of Debian (mostly the Makefile adjustments to allow for hardening CFLAGS/LDFLAGS), none are specific to Debian and should be fine to merge for general use.

Note that I have not actually tested the platform patch on AIX, but have double checked with its getopt documentation that the non-platform-specific changes will work the same on AIX as other platforms.

Please also merge PR #1, which is in my patchset but not included here.