### PR TITLE
Recognize DS2401 variant family 0x81 in DS9490R/DS9490B

### DIFF
--- a/src/device_name.c
+++ b/src/device_name.c
@@ -128,6 +128,9 @@ char *device_name( unsigned int family )
     case 0x42:
       return "DS28EA00 Temperature Sensor with Sequence Detect and PIO";
 
+    case 0x81:
+      return "DS2401 Serial Number (DS9490R/DS9490B)";
+
     case 0x82:
       return "DS1425 Multi iButton";
       


### PR DESCRIPTION
The DS9490R/DS9490B contains a "custom" DS2401:

    Each USB bridge contains a unique built-in identification chip. The
    identification chip is a custom DS2401 that is a 64-bit ID number
    (see Figure 3).

[http://datasheets.maximintegrated.com/en/ds/DS9490-DS9490R.pdf]

The "custom" part of it appears to vary from the standard DS2401 01h
family by:

    1) It's family 0x81 instead of 0x01.
    2) The 12 bits before the CRC are zero.

Don't khow why that necessitated a new family, but okay.

DigiTemp v3.6.0 Copyright 1996-2015 by Brian C. Lane
GNU General Public License v2.0 - http://www.digitemp.com
Found DS2490 device #1 at 001/006
Turning off all DS2409 Couplers
...
Devices on the Main LAN
28D1483C0200002F : DS18B20 Temperature Sensor
28E9393C020000C3 : DS18B20 Temperature Sensor
81405735000000D2 : DS2401 Serial Number (DS9490R/DS9490B)