### PR TITLE
Spelling corrections

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -157,7 +157,7 @@
 		Changed version # to v3.0.0
 
 08/21/2002      Small bug with -i crept in, it wants another command to be
-                present, it won't just initalize.
+                present, it won't just initialize.
 
 08/18/2002	Added %N token to allow the time in seconds since Epoch to
 		be selected in the output.
@@ -182,7 +182,7 @@
 		exit if the user doesn't have access to the serial device.
 
 06/23/2002      Releasing new version today. Really! Making -q turn off 
-                the extra output I added for initalizing the 1-wire lan.
+                the extra output I added for initializing the 1-wire lan.
 
 06/08/2002      Adding patches from John. exit() codes are now #defines
                 and .digitemprc now outputs the serial numbers as hex
@@ -339,7 +339,7 @@
                 Adding support for the DS9097-U adapter for the Linux
                 version. The Solaris version will need changes to be able
                 to support the DS9097-U.
-                Changed license to GNU Public License v2.0
+                Changed license to GNU General Public License v2.0
                 Added the -q option to make the banner disappear.
 
 01/01/2000      Well, no release last year. Adding -q to make the banner
@@ -402,7 +402,7 @@
 08/31/1998      Adding a check for family 0x10 so that we can read DS1820s
                 while they are on a network that includes other 1-wire
                 devices.
-                Fixed a problem with freeing uninitalized rom_list when
+                Fixed a problem with freeing uninitialized rom_list when
                 starting a SearchROM. Not sure why this never appeared
                 before.
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Makefile for DigiTemp
 #
 # Copyright 1996-2015 by Brian C. Lane <bcl@brianlane.com>
-# See COPYING for GNU Public License
+# See COPYING for GNU General Public License
 #
 # Please note that this Makefile *needs* GNU make. BSD make won't do.
 #

--- a/README
+++ b/README
@@ -33,7 +33,7 @@ see if it 'Just Works':
     If you had my 1-wire setup (hub and sensors) you would see this:
 
 	DigiTemp v3.3.0 Copyright 1996-2004 by Brian C. Lane
-	GNU Public License v2.0 - http://www.brianlane.com
+	GNU General Public License v2.0 - http://www.brianlane.com
 	Turning off all DS2409 Couplers
 	...
 	Searching the 1-Wire LAN
@@ -66,7 +66,7 @@ see if it 'Just Works':
     Again, if you were using the same 1-wire lan as I am you would see:
 
 	DigiTemp v3.3.0 Copyright 1996-2004 by Brian C. Lane
-	GNU Public License v2.0 - http://www.brianlane.com
+	GNU General Public License v2.0 - http://www.brianlane.com
 	Jan 11 08:33:41 Sensor 0 C: 22.50 F: 72.50
 	Jan 11 08:33:42 Sensor 1 C: 31.44 F: 88.59
 	Jan 11 08:33:43 Sensor 2 C: 21.56 F: 70.81
@@ -178,7 +178,7 @@ connected to the branch of another coupler). The output will identify each
 device connected, even if it isn't a sensor that DigiTemp supports.
 
 	DigiTemp v3.3.0 Copyright 1996-2003 by Brian C. Lane
-	GNU Public License v2.0 - http://www.brianlane.com
+	GNU General Public License v2.0 - http://www.brianlane.com
 	Turning off all DS2409 Couplers
 
 	Devices on the Main LAN
@@ -260,7 +260,7 @@ raw voltages from the DS2438. The format string for this is hard-coded and
 the output looks like this:
 
 	DigiTemp v3.3.0 Copyright 1996-2003 by Brian C. Lane
-	GNU Public License v2.0 - http://www.brianlane.com
+	GNU General Public License v2.0 - http://www.brianlane.com
 	Jan 11 16:56:00 Sensor 6 VDD: 4.70 AD: 1.46 C: 27.94
 
 
@@ -444,7 +444,7 @@ when repeatedly reading multiple sensors.
 
   Version 2.5 adds compilation under Solaris. A new log option of %R has
 been added to output the serial number in hex in the logging output string.
-The quiet -q option now quiets down the 1-Wire walk and initalize routine so
+The quiet -q option now quiets down the 1-Wire walk and initialize routine so
 that only the important information is output.
 
   Version 2.4 fixes the problems (finally!) with the DS18B20 and DS1822
@@ -456,9 +456,9 @@ be found at www.simat.enta.net
 
   Version 2.x.x removes support for the old adapter (based on the one
 described in App. Note 74 from Dallas Semiconductor. Version 1.3 still
-supports the older adapters and is now also released under the GNU public
-license). This new version uses the DS9097-U adapter available from Dallas
-Semiconductor. You can order them from their iButton webpage at
+supports the older adapters and is now also released under the GNU General
+Public License). This new version uses the DS9097-U adapter available from
+Dallas Semiconductor. You can order them from their iButton webpage at
 www.ibutton.com
 
   This adapter is more expensive but is easier to program and support higher

--- a/perl/maxplot
+++ b/perl/maxplot
@@ -168,7 +168,7 @@ close(DOTTEMP);
 # Now all the temps are in dottemp -- it might be better to read it line
 # by line for bigger files?
 
-# Initalize the initial variables - I should use a list for this
+# Initialize the initial variables - I should use a list for this
 $x = $hmargin;
 $_= $dottemp[0];
 @_ = split( " ", $_ );

--- a/rrdb/README
+++ b/rrdb/README
@@ -24,6 +24,6 @@
 
   The suggested initialization sets up digitemp to output the temperature in
   Centigrade and the conversion to Fahrenheit. The -o option passed to
-  digitemp when it is initalized controls how the temperature is output.
+  digitemp when it is initialized controls how the temperature is output.
 
 

--- a/rrdb/log_temp
+++ b/rrdb/log_temp
@@ -23,7 +23,7 @@
 # your root directory or specify the configuration file using -c filename
 # on the digitemp command line in the reading variable below.
 
-# Get the current temperatures, digitemp has been previously initalized with
+# Get the current temperatures, digitemp has been previously initialized with
 # digitemp -i -s /dev/ttyS0 -o2 -a
 
 # Run it in quiet mode, output is 0\tsensor#1\tsensor#2\tsensor#3

--- a/src/digitemp.c
+++ b/src/digitemp.c
@@ -19,7 +19,7 @@
    59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
    
      digitemp -w                        Walk the LAN & show all
-     digitemp -i			Initalize .digitemprc file
+     digitemp -i			Initialize .digitemprc file
      digitemp -I                        Initialize .digitemprc w/sorted serial #s
      digitemp -s/dev/ttyS0		Set serial port (required)
      digitemp -cdigitemp.conf		Configuration File
@@ -40,7 +40,7 @@
 
      Logfile formats:
      1 = (default) - 1 line per sensor, time, C, F
-         1 line for each sample, elapsed time, sensor #1, #2, ... tab seperated
+         1 line for each sample, elapsed time, sensor #1, #2, ... tab separated
      2 = Reading in C
      3 = Reading in F
 
@@ -2038,7 +2038,7 @@ int Init1WireLan( struct _roms *sensor_list )
   /* Free up the coupler list */
   free_coupler(0);
 
-  /* Initalize the coupler pointer */
+  /* Initialize the coupler pointer */
   coupler_end = coupler_top;
 
   if( !(opts & OPT_QUIET) )
@@ -2402,7 +2402,7 @@ int main( int argc, char *argv[] )
       case 'w': opts |= OPT_WALK;               /* Walk the LAN         */
                 break;
     
-      case 'i':	opts |= OPT_INIT;		/* Initalize the s#'s	*/
+      case 'i':	opts |= OPT_INIT;		/* Initialize the s#'s	*/
       		break;
       		
       case 'r':	tmp_read_time = atoi(optarg);	/* Read delay in mS	*/
@@ -2617,7 +2617,7 @@ int main( int argc, char *argv[] )
 
 
   /* ------------------------------------------------------------------*/
-  /* Should we initalize the sensors?                                  */
+  /* Should we initialize the sensors?                                  */
   /* This should store the serial numbers to the .digitemprc file      */
   if( opts & OPT_INIT )
   {

--- a/userial/ds2490/owtran.c
+++ b/userial/ds2490/owtran.c
@@ -42,7 +42,7 @@
 // 1-Wire Net with an optional reset at the begining of communication.
 // The result is returned in the same buffer.
 //
-// 'do_reset' - cause a owTouchReset to occure at the begining of
+// 'do_reset' - cause a owTouchReset to occur at the begining of
 //              communication TRUE(1) or not FALSE(0)
 // 'tran_buf' - pointer to a block of unsigned
 //              chars of length 'TranferLength' that will be sent

--- a/userial/ds9097/owerr.c
+++ b/userial/ds9097/owerr.c
@@ -136,7 +136,7 @@ int owHasErrors(void)
    //
    // Arguments:  int err - the error code you wish to raise.
    //             int lineno - DEBUG only - the line number where it was raised
-   //             char* filename - DEBUG only - the file name where it occured.
+   //             char* filename - DEBUG only - the file name where it occurred.
    //
    void owRaiseError(int err, int lineno, char* filename)
    {
@@ -267,7 +267,7 @@ int owHasErrors(void)
    /*097*/ "Failed to create a challenge on the coprocessor.",
    /*098*/ "Transaction Incomplete: service data was not valid.",
    /*099*/ "Transaction Incomplete: service data was not updated.",
-   /*100*/ "Unrecoverable, catastrophic service failure occured.",
+   /*100*/ "Unrecoverable, catastrophic service failure occurred.",
    /*101*/ "Load First Secret from scratchpad data failed.",
    /*102*/ "Failed to match signature of user's service data."
    };

--- a/userial/ds9097/owtran.c
+++ b/userial/ds9097/owtran.c
@@ -42,7 +42,7 @@
 // 1-Wire Net with an optional reset at the begining of communication.
 // The result is returned in the same buffer.
 //
-// 'do_reset' - cause a owTouchReset to occure at the begining of
+// 'do_reset' - cause a owTouchReset to occur at the begining of
 //              communication TRUE(1) or not FALSE(0)
 // 'tran_buf' - pointer to a block of unsigned
 //              chars of length 'TranferLength' that will be sent

--- a/userial/ds9097u/owllu.c
+++ b/userial/ds9097u/owllu.c
@@ -139,7 +139,7 @@ SMALLINT owTouchReset(int portnum)
    else
       OWERROR(OWERROR_WRITECOM_FAILED);
 
-   // an error occured so re-sync with DS2480
+   // an error occurred so re-sync with DS2480
    DS2480Detect(portnum);
 
    return FALSE;
@@ -199,7 +199,7 @@ SMALLINT owTouchBit(int portnum, SMALLINT sendbit)
    else
       OWERROR(OWERROR_WRITECOM_FAILED);
 
-   // an error occured so re-sync with DS2480
+   // an error occurred so re-sync with DS2480
    DS2480Detect(portnum);
 
    return 0;
@@ -289,7 +289,7 @@ SMALLINT owTouchByte(int portnum, SMALLINT sendbyte)
    else
       OWERROR(OWERROR_WRITECOM_FAILED);
 
-   // an error occured so re-sync with DS2480
+   // an error occurred so re-sync with DS2480
    DS2480Detect(portnum);
 
    return 0;
@@ -547,7 +547,7 @@ SMALLINT owProgramPulse(int portnum)
    else
       OWERROR(OWERROR_WRITECOM_FAILED);
 
-   // an error occured so re-sync with DS2480
+   // an error occurred so re-sync with DS2480
    DS2480Detect(portnum);
 
    return FALSE;

--- a/userial/ds9097u/ownetu.c
+++ b/userial/ds9097u/ownetu.c
@@ -300,7 +300,7 @@ SMALLINT owNext(int portnum, SMALLINT do_reset, SMALLINT alarm_only)
    else
       OWERROR(OWERROR_WRITECOM_FAILED);
    
-   // an error occured so re-sync with DS2480
+   // an error occurred so re-sync with DS2480
    DS2480Detect(portnum);
 
    // reset the search

--- a/userial/ds9097u/owtrnu.c
+++ b/userial/ds9097u/owtrnu.c
@@ -86,7 +86,7 @@ static SMALLINT Copy_Scratchpad(int,int,SMALLINT);
 //
 // 'portnum'  - number 0 to MAX_PORTNUM-1.  This number is provided to
 //              indicate the symbolic port number.
-// 'do_reset' - cause a owTouchReset to occure at the begining of
+// 'do_reset' - cause a owTouchReset to occur at the begining of
 //              communication TRUE(1) or not FALSE(0)
 // 'tran_buf' - pointer to a block of unsigned
 //              chars of length 'tran_len' that will be sent
@@ -159,7 +159,7 @@ SMALLINT owBlock(int portnum, SMALLINT do_reset, uchar *tran_buf, SMALLINT tran_
    else
       OWERROR(OWERROR_WRITECOM_FAILED);
 
-   // an error occured so re-sync with DS2480
+   // an error occurred so re-sync with DS2480
    DS2480Detect(portnum);
 
    return FALSE;

--- a/userial/owerr.c
+++ b/userial/owerr.c
@@ -136,7 +136,7 @@ int owHasErrors(void)
    //
    // Arguments:  int err - the error code you wish to raise.
    //             int lineno - DEBUG only - the line number where it was raised
-   //             char* filename - DEBUG only - the file name where it occured.
+   //             char* filename - DEBUG only - the file name where it occurred.
    //
    void owRaiseError(int err, int lineno, char* filename)
    {
@@ -267,7 +267,7 @@ int owHasErrors(void)
    /*097*/ "Failed to create a challenge on the coprocessor.",
    /*098*/ "Transaction Incomplete: service data was not valid.",
    /*099*/ "Transaction Incomplete: service data was not updated.",
-   /*100*/ "Unrecoverable, catastrophic service failure occured.",
+   /*100*/ "Unrecoverable, catastrophic service failure occurred.",
    /*101*/ "Load First Secret from scratchpad data failed.",
    /*102*/ "Failed to match signature of user's service data."
    };


### PR DESCRIPTION
Correct occured -> occurred as found by lintian.

A previous commit fixed some other spelling errors, but that was just in
binary output (which lintian could easily detect).  This also goes back
and corrects comments/docs/etc with those found errors.