### PR TITLE
FIX: compiling using musl fails due to missing sys/types.h inclusion

### DIFF
--- a/src/ds2438.c
+++ b/src/ds2438.c
@@ -5,6 +5,7 @@
    Licensed under GPL v2
    ----------------------------------------------------------------------- */
 #include <stdio.h>
+#include <sys/types.h>
 #include "ownet.h"
 #include "ad26.h"
 

--- a/userial/ad26.c
+++ b/userial/ad26.c
@@ -30,6 +30,7 @@
 
 // Include Files
 #include <stdio.h>
+#include <sys/types.h>
 #include "ownet.h"
 #include "ad26.h"
 #include "owproto.h"

--- a/userial/cnt1d.c
+++ b/userial/cnt1d.c
@@ -29,6 +29,7 @@
 //  Version: 2.00
 //
 //
+#include <sys/types.h>
 #include "ownet.h"
 
 // external One Wire functions from nework layer

--- a/userial/crcutil.c
+++ b/userial/crcutil.c
@@ -28,6 +28,7 @@
 //  version 2.00
 
 // Include files
+#include <sys/types.h>
 #include "ownet.h"
 
 // Local subroutines

--- a/userial/ds9097u/owtrnu.c
+++ b/userial/ds9097u/owtrnu.c
@@ -39,6 +39,7 @@
 //                        Added file I/O operations
 //
 
+#include <sys/types.h>
 #include "ownet.h"
 #include "ds2480.h"
 

--- a/userial/ioutil.c
+++ b/userial/ioutil.c
@@ -35,6 +35,7 @@
 #include <signal.h>
 #include <string.h>
 #include <ctype.h>
+#include <sys/types.h>
 #include "ownet.h"
 
 #ifdef __MC68K__

--- a/userial/owproto.h
+++ b/userial/owproto.h
@@ -1,3 +1,6 @@
+/* include files */
+#include <sys/types.h>
+
 /* Prototypes for userial driver functions */
 
 /* From other low level userial files */


### PR DESCRIPTION
compiling using musl (as used by OpenWRT) fails with the following error:

src/ds2438.c:29:4: error: unknown type name 'ushort'
ushort lastcrc8=255;

fixed by inclusion of <sys/types.h> in every file that uses unsigned types. 
