### PR TITLE
Ds2438 logformat

### DIFF
--- a/digitemp.1
+++ b/digitemp.1
@@ -93,6 +93,9 @@ See Temperature Format below.
 .TP
 .B \-H"Humidity format string"
 See Humidity Format below.
+.TP
+.B \-V"ADC format"
+See voltage ADC format below.
 .PP
 .SH
 Temperature Format
@@ -156,6 +159,17 @@ with the addition of this format specifier:
 .TP
 .B %h
 is the humidity in 0-100%
+.PP
+.SH
+Voltage Format String
+.PP
+The A/D converter (ADC) format is the same as the temperature format
+string with the addition of two format specifiers:
+.TP
+.B %Q
+for VDD measurement (in unit of Volt), and
+.B %q
+for the analog input voltage (in unit of Volt).
 .PP
 .SH AUTHOR
 This manual page was written by Jes\['u]s Roncero <jesus@roncero.org>,

--- a/digitemp.1
+++ b/digitemp.1
@@ -167,9 +167,10 @@ The A/D converter (ADC) format is the same as the temperature format
 string with the addition of two format specifiers:
 .TP
 .B %Q
-for VDD measurement (in unit of Volt), and
+for Vdd measurement (unit V "Volt"), 
 .B %q
-for the analog input voltage (in unit of Volt).
+for the analog input voltage Vad (unit V "Volt"), and
+.B %J for Vsense (unit mV).
 .PP
 .SH AUTHOR
 This manual page was written by Jes\['u]s Roncero <jesus@roncero.org>,

--- a/src/digitemp.c
+++ b/src/digitemp.c
@@ -170,7 +170,7 @@ void usage()
   printf("        %%n is the counter # and %%C is the count in decimal.\n");
   printf("        The humidity format uses %%h for the humidity in percent\n\n");
   printf("        The A/D converter format uses %%Q for Vd and %%q for the analog\n");
-  printf("        input voltage Vad, both measured in Volt; %J gives Vsense in mV.\n\n");
+  printf("        input voltage Vad, both measured in Volt; %%J gives Vsense in mV.\n\n");
   printf("        The logfile may contain strftime pattern to format the filename\n");
 }
 

--- a/src/digitemp.h
+++ b/src/digitemp.h
@@ -94,13 +94,15 @@ int build_tf( char *time_format, char *format, int sensor,
 int build_cf( char *time_format, char *format, int sensor, int page,
               unsigned long count, unsigned char *sn );
 int build_af(char *time_format, size_t tf_size, char *format,
-             int sensor, float temp_c, float vdd, float ad, unsigned char *sn);
+             int sensor, float temp_c, float vdd, float ad, float vsens,
+             unsigned char *sn);
 int log_string( char *line );
 int log_temp( int sensor, float temp_c, unsigned char *sn );
 int log_counter( int sensor, int page, unsigned long counter, unsigned char *sn );
 int log_humidity( int sensor, double temp_c, int humidity, unsigned char *sn );
 int log_temperature_voltage(int sensor, double temp_c,
-                            float vdd, float ad, unsigned char *sn);
+                            float vdd, float ad, float vsens,
+                            unsigned char *sn);
 int cmpSN( unsigned char *sn1, unsigned char *sn2, int branch );
 void show_scratchpad( unsigned char *scratchpad, int sensor_family );
 int read_temperature( int sensor_family, int sensor );

--- a/src/digitemp.h
+++ b/src/digitemp.h
@@ -93,10 +93,14 @@ int build_tf( char *time_format, char *format, int sensor,
               float temp_c, int humidity, unsigned char *sn );
 int build_cf( char *time_format, char *format, int sensor, int page,
               unsigned long count, unsigned char *sn );
+int build_af(char *time_format, size_t tf_size, char *format,
+             int sensor, float temp_c, float vdd, float ad, unsigned char *sn);
 int log_string( char *line );
 int log_temp( int sensor, float temp_c, unsigned char *sn );
 int log_counter( int sensor, int page, unsigned long counter, unsigned char *sn );
 int log_humidity( int sensor, double temp_c, int humidity, unsigned char *sn );
+int log_temperature_voltage(int sensor, double temp_c,
+                            float vdd, float ad, unsigned char *sn);
 int cmpSN( unsigned char *sn1, unsigned char *sn2, int branch );
 void show_scratchpad( unsigned char *scratchpad, int sensor_family );
 int read_temperature( int sensor_family, int sensor );


### PR DESCRIPTION
Hi,

I added some code to support setting a log output format for the DS2438 in ADC mode (-A option):
* -V to specify the format on the command line
* support in rc file
* using tokens %Q for Vdd, %q for Vad, %J for Vsense
* documentation in usage() function as well as man page
* test code to verify that the build_af() function works and does not write out of buffer can be called using -T

Best regards
Ulric