### PR TITLE
Ds2438 fixes

### DIFF
--- a/userial/ad26.c
+++ b/userial/ad26.c
@@ -251,10 +251,17 @@ float Volt_Reading(int portnum, int vdd, int *cad)
 	    if(cad) {
 
 	      /* Get Current reading as well */
+              /* convert from 12-bit 2's complement, see
+               * https://en.wikipedia.org/wiki/Two%27s_complement
+               */
 	      c = send_block[8] & 0x3;
-
 	      *cad =  (c << 8) | send_block[7];
-	      if(send_block[8] & 0x4) *cad =  - *cad;
+	      if(send_block[8] & 0x4) {
+                      /* Negative value represented by set sign bit
+                       * with weight of -2^12
+                       */
+                      *cad = *cad - 4096;
+              }
 
 	      //	      printf("CAD=%d\n", *cad);
 	    }


### PR DESCRIPTION
Dear Brian,

I noticed that the conversion of the Vsense data seems incorrect if the returned number is negative, i.e. with the sign bit(s) set. As per the data sheet the register value is a 12+1 bit 2's complement value, so the negation of the 12 unsigned value is not the correct way to handle this situation. Please find a fix in the supplied patch.

Best regards,
Ulrich