### PR TITLE
Fix conflicting prototype

### DIFF
--- a/src/digitemp.h
+++ b/src/digitemp.h
@@ -87,7 +87,7 @@ struct _coupler {
 
 /* Prototypes */
 void usage();
-void free_coupler();
+void free_coupler( int free_only );
 float c2f( float temp );
 int build_tf( char *time_format, char *format, int sensor, 
               float temp_c, int humidity, unsigned char *sn );


### PR DESCRIPTION
Build failure on Fedora Rawide using GCC 15 without this patch:

```
src/digitemp.c:171:6: error: conflicting types for ‘free_coupler’; have ‘void(int)’
  171 | void free_coupler( int free_only )
      |      ^~~~~~~~~~~~
In file included from src/digitemp.c:78:
src/digitemp.h:90:6: note: previous declaration of ‘free_coupler’ with type ‘void(void)’
   90 | void free_coupler();
      |      ^~~~~~~~~~~~
```